### PR TITLE
Added flag to VS Code to not enable the python venv again

### DIFF
--- a/.pcode_python/.vscode/settings.json
+++ b/.pcode_python/.vscode/settings.json
@@ -1,8 +1,9 @@
 {
     "python.pythonPath": "venv\\Scripts\\python.exe",
-     "python.linting.pylintArgs": [
+    "python.linting.pylintArgs": [
         "--extension-pkg-whitelist=wx"
     ],
+    "python.terminal.activateEnvironment": false,
     "terminal.integrated.env.windows": {
         "PYTHONPATH": "${workspaceRoot}"
     }


### PR DESCRIPTION
Found the VS Code I use calls activate.ps1 after running the scripts from VS Code itself.