### PR TITLE
Initial fix for PyInstall array issue...

### DIFF
--- a/tests/pcode_python/build.tests.ps1
+++ b/tests/pcode_python/build.tests.ps1
@@ -127,4 +127,30 @@ Describe "Python Installations from Windows Store" {
                 "python.exe"))
         }
     }
+
+    context "Get-PythonInstalls with one Python installation" {
+
+        # Have just one install from the Windows Store
+        Mock Get-AppxPackage { return [PSCustomObject]@{
+            "Name" = "PythonSoftwareFoundation.Python.3.7"
+            "PackageFamilyName" = "PythonSoftwareFoundation.Python.3.7_qbz5n2kfra8p0"
+        }}
+
+        Mock Test-Path { return $true }
+
+        # Disables Get-PythonFromRegistry so it won't detect local installs
+        Mock Get-PythonFromRegistry { return $null }
+
+        Mock Get-PythonInfo { return [PSCustomObject]@{
+            FullPath = "TestPythonWindowsStore"
+        }}
+
+        [array]$installs = Get-PythonInstalls
+
+        It "Get-PythonInstalls query returns 1 item" {
+            $installs.Count | Should Be 1
+            $installs[0].FullPath | Should Be "TestPythonWindowsStore"
+        }
+
+    }
 }


### PR DESCRIPTION
Found a bug where if there are less than 2 Python installations in the registry then the variable the installations were stored in would not be an array.

The code is broken apart to aid in testing and the variable is initialized as an empty array before adding the installs.